### PR TITLE
Error en fir_matlab_to_C.m al llamar my_dft

### DIFF
--- a/05_fir-filtering/fir_matlab_to_C.m
+++ b/05_fir-filtering/fir_matlab_to_C.m
@@ -46,8 +46,8 @@ legend('FILTERED SIGNAL')
 
 %% PLOT IN FREQ
 
-[~, f1, ~, ~, H_signal_f, ~, ~] = my_dft(signal_f, Fs);
-[~, f2, ~, ~, H_output_c, ~, ~] = my_dft(output_c, Fs);
+[f1, H_signal_f, ~, ~, ~] = my_dft(signal_f, Fs);
+[f2, H_output_c, ~, ~, ~] = my_dft(output_c, Fs);
 
 figure
 subplot(2,1,1)


### PR DESCRIPTION
Profe me salió un error al ejecutar el script `fir_matlab_to_C.m`. Tengo entendido que es al llamar la función **my_dft**, en los parámetros. 

```Matlab
[f, dft_mag, dft_phase, dft, NFFT] = my_dft(data, Fs)
```

Realizo el *pull request* pero no estoy del todo seguro si realmente es un error o yo estoy haciendo algo mal.